### PR TITLE
return http response when fail

### DIFF
--- a/.generator/templates/client.mustache
+++ b/.generator/templates/client.mustache
@@ -1170,7 +1170,7 @@ func (c *APIClient) do(ctx context.Context, req *http.Request) (*http.Response, 
 		}
 		resp, err := c.doWithRetries(ctx, req)
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 && req.Method == http.MethodGet {
 			if c.cfg.Okta.Client.RateLimit.Enable {

--- a/okta/client.go
+++ b/okta/client.go
@@ -1357,7 +1357,7 @@ func (c *APIClient) do(ctx context.Context, req *http.Request) (*http.Response, 
 		}
 		resp, err := c.doWithRetries(ctx, req)
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 && req.Method == http.MethodGet {
 			if c.cfg.Okta.Client.RateLimit.Enable {


### PR DESCRIPTION
Return the http response, so we can extract and parse the headers